### PR TITLE
update: Refactor order cancellation logic and update DTO

### DIFF
--- a/BLL/DTO/Order/OrderUpdateDTO.cs
+++ b/BLL/DTO/Order/OrderUpdateDTO.cs
@@ -6,8 +6,8 @@ namespace BLL.DTO.Order;
 public class OrderUpdateDTO
 {
     // [Required(ErrorMessage = "Trạng thái đơn hàng là bắt buộc.")]
-    [EnumDataType(typeof(OrderStatus), ErrorMessage = "Trạng thái phải là Pending, Confirmed, Processing, Shipped, Delivered, Cancelled hoặc Refunded")]
-    public OrderStatus? Status { get; set; }
+    // [EnumDataType(typeof(OrderStatus), ErrorMessage = "Trạng thái phải là Pending, Confirmed, Processing, Shipped, Delivered, Cancelled hoặc Refunded")]
+    // public OrderStatus? Status { get; set; }
 
     // [StringLength(100, ErrorMessage = "Mã vận đơn (TrackingNumber) không được vượt quá 100 ký tự.")]
     // public string? TrackingNumber { get; set; }

--- a/Controller/Controllers/OrderController.cs
+++ b/Controller/Controllers/OrderController.cs
@@ -79,7 +79,7 @@ public class OrderController : BaseController
     [HttpPatch("{orderId}")]
     [Authorize]
     [EndpointSummary("Update Order (PATCH)")]
-    [EndpointDescription("Khi đã có CancelledReason, trạng thái đơn hàng nhận vào phải là null hoặc Cancelled. Không thể hủy đơn khi trạng thái đã là Shipped hoặc Delivered.")]
+    [EndpointDescription("Nếu truyền CancelledReason đồng nghĩa với xác nhận hủy đơn. Không thể hủy đơn khi trạng thái đã là Shipped hoặc Delivered.")]
     public async Task<ActionResult<APIResponse>> UpdateOrder(ulong orderId, [FromBody] OrderUpdateDTO dto)
     {
         var validationResult = ValidateModel();


### PR DESCRIPTION
Removed Status property from OrderUpdateDTO and refactored OrderService to set order status to Cancelled when CancelledReason is provided, with validation to prevent cancellation if order is already shipped or delivered. Updated endpoint description in OrderController for clarity.